### PR TITLE
Test verilog_int using detail systemc model

### DIFF
--- a/common/include/verilog_int.h
+++ b/common/include/verilog_int.h
@@ -152,9 +152,9 @@ struct vint {
 			for (unsigned i = num_word; i > 0;) {
 				--i;
 				if (v[i] > rhs.v[i]) {
-					return -1;
-				} else if (v[i] < rhs.v[i]) {
 					return 1;
+				} else if (v[i] < rhs.v[i]) {
+					return -1;
 				}
 			}
 		}

--- a/common/include/verilog_int.h
+++ b/common/include/verilog_int.h
@@ -142,31 +142,68 @@ struct vint {
 	//////////////////////
 	// comparison
 	//////////////////////
-	// TODO > < >= <= !=
-	bool operator==(const vint& rhs) const {
-		return ::std::equal(::std::begin(v), ::std::end(v), ::std::begin(rhs.v));
-	}
 
-	bool operator==(const dtype rhs) const {
-		bool sign_ok = true;
+	// compare() will return:
+	// 1: larger
+	// 0: must check further
+	// -1: smaller
+	int compare(const vint& rhs) const {
 		if constexpr (num_word > 1) {
-			const dtype expected_sign = (is_signed and rhs < 0) ? -1 : 0;
-			for (unsigned i = 1; i < num_word; ++i) {
-				if (v[i] != expected_sign) {
-					sign_ok = false;
-					break;
+			for (unsigned i = num_word; i > 0;) {
+				--i;
+				if (v[i] > rhs.v[i]) {
+					return -1;
+				} else if (v[i] < rhs.v[i]) {
+					return 1;
 				}
 			}
 		}
-		return v[0] == rhs and sign_ok;
+		return 0;
 	}
 
-	bool operator!=(const vint& rhs) const {
-		return not (*this == rhs);
+	int compare(const dtype rhs) const {
+		if constexpr (num_word > 1) {
+			const dtype expected_sign = (is_signed and rhs < 0) ? -1 : 0;
+			for (unsigned i = num_word; i > 1;) {
+				--i;
+				if (v[i] > expected_sign) {
+					return -1;
+				} else if (v[i] < expected_sign) {
+					return 1;
+				}
+			}
+		}
+		return 0;
 	}
 
-	bool operator!=(const dtype rhs) const {
-		return not (*this == rhs);
+	bool operator==(const vint& rhs) const { return compare(rhs) == 0; }
+	bool operator>(const vint& rhs) const { return compare(rhs) > 0; }
+	bool operator<(const vint& rhs) const { return compare(rhs) < 0; }
+	bool operator>=(const vint& rhs) const { return compare(rhs) >= 0; }
+	bool operator<=(const vint& rhs) const { return compare(rhs) <= 0; }
+
+	bool operator==(const dtype rhs) const {
+		return compare(rhs) == 0 and v[0] == rhs;
+	}
+
+	bool operator>(const dtype rhs) const {
+		const int cmp = compare(rhs);
+		return cmp > 0 or cmp == 0 and v[0] > rhs;
+	}
+
+	bool operator<(const dtype rhs) const {
+		const int cmp = compare(rhs);
+		return cmp < 0 or cmp == 0 and v[0] < rhs;
+	}
+
+	bool operator>=(const dtype rhs) const {
+		const int cmp = compare(rhs);
+		return cmp > 0 or cmp == 0 and v[0] >= rhs;
+	}
+
+	bool operator<=(const dtype rhs) const {
+		const int cmp = compare(rhs);
+		return cmp < 0 or cmp == 0 and v[0] <= rhs;
 	}
 
 	//////////////////////
@@ -314,6 +351,23 @@ struct vint {
 		return ret;
 	}
 
+	vint operator-() {
+		vint ret;
+		if (num_word == 1) {
+			ret.v[0] = -v[0];
+		} else {
+			unsigned char carry = 0;
+			carry = detail::addcarry64(v[0], ~v[0], dtype(1), carry);
+			for (unsigned i = 1; i < num_word; ++i) {
+				carry = detail::addcarry64(v[i], ~v[i], 0, carry);
+			}
+		}
+		if constexpr (not is_signed) {
+			ClampBits();
+		}
+		return ret;
+	}
+
 	operator bool() {
 		for (auto &x: v) {
 			if (x) {
@@ -400,7 +454,7 @@ struct vint {
 	}
 
 	//////////////////////
-	// binary operators
+	// derived operators
 	//////////////////////
 	vint operator+(const vint& rhs) { vint ret = *this; ret += rhs; return ret; }
 	vint operator-(const vint& rhs) { vint ret = *this; ret -= rhs; return ret; }
@@ -411,6 +465,7 @@ struct vint {
 	vint operator^(const vint& rhs) { vint ret = *this; ret ^= rhs; return ret; }
 	vint operator>>(const vint& rhs) { vint ret = *this; ret >>= rhs; return ret; }
 	vint operator<<(const vint& rhs) { vint ret = *this; ret <<= rhs; return ret; }
+	bool operator!=(const vint& rhs) const { return not (*this == rhs); }
 
 	vint operator+(const dtype rhs) { vint ret = *this; ret += rhs; return ret; }
 	vint operator-(const dtype rhs) { vint ret = *this; ret -= rhs; return ret; }
@@ -421,6 +476,7 @@ struct vint {
 	vint operator^(const dtype rhs) { vint ret = *this; ret ^= rhs; return ret; }
 	vint operator>>(const dtype rhs) { vint ret = *this; ret >>= rhs; return ret; }
 	vint operator<<(const dtype rhs) { vint ret = *this; ret <<= rhs; return ret; }
+	bool operator!=(const dtype rhs) const { return not (*this == rhs); }
 
 	//////////////////////
 	// slice

--- a/systemc/model_two_power_mod.cpp
+++ b/systemc/model_two_power_mod.cpp
@@ -12,7 +12,7 @@ using namespace sc_dt;
 using namespace verilog;
 
 constexpr int kBW = 256;
-typedef vint<false, 256> KeyType;
+typedef vint<false, 257> KeyType;
 
 SC_MODULE(RSATwoPowerMod)
 {
@@ -28,27 +28,28 @@ SC_MODULE(RSATwoPowerMod)
 
 	void Thread()
 	{
-		mpz_t modulus, out;
-		mpz_inits(modulus, out);
-		char str[256];
-
+		KeyType round_result;
 		while (true)
 		{
 			int power = i_power.read();
-			KeyType data = i_modulus.read();
-			mpz_set_str(modulus, to_hex(data).c_str(), 16);
+			KeyType modulus = i_modulus.read();
 
-			two_power_mod(out, power, modulus);
-
-			gmp_snprintf(str, 256, "0x%ZX", out);
-			from_hex(data, str);
-			o_out.write(data);
+			from_hex(round_result, "1");
+			for (size_t i = 0; i < power; i++)
+			{
+				round_result <<= 1;
+				if (round_result > modulus)
+				{
+					round_result -= modulus;
+				}
+			}
+			o_out.write(round_result);
 		}
 	}
 };
 
 const char str_modulus[] = "0xE07122F2A4A9E81141ADE518A2CD7574DCB67060B005E24665EF532E0CCA73E1";
-const char str_ans[] = "AF39E1F831CB4FCD92B17F61F473735C687593A931C97D2B60AD6C7443F09FDB";
+const char str_ans[] = "0AF39E1F831CB4FCD92B17F61F473735C687593A931C97D2B60AD6C7443F09FDB";
 const int power = 512;
 SC_MODULE(Testbench)
 {


### PR DESCRIPTION
@johnjohnlin 
I implemented the model of calculating "2 ^ 512 mod N" using verilog_int.
The test passed.
Though I have to use `vint<false, 257>` as keytype to overcome the problem that 2^257 will overflow the data. Since MSB of N is 1, without doing so the 2 ^ x will never larger than N.