### PR TITLE
Install verilator in github action

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -8,21 +8,24 @@ env:
 
 jobs:
   build_cmake:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-22.04
 
     steps:
     - name: Install Required Package
-      run: sudo apt install -y libgtest-dev libgmp-dev build-essential cmake libsystemc-dev libgtest-dev
-        python3 wget autoconf perl flex bison zlib1g-dev
+      run: sudo apt update &&
+        sudo apt install -y libgtest-dev libgmp-dev build-essential cmake libsystemc-dev libgtest-dev
+        python3 wget autoconf perl flex bison zlib1g-dev libfl-dev
 
     - uses: actions/checkout@v3
 
+    - name: Run install_verilator.sh
+      run: mkdir custom_package && cd custom_package && ${{github.workspace}}/docker/install_verilator.sh
+      shell: bash
+      env:
+        THE_PREFIX: /usr/
+        SUDO: sudo
+
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build

--- a/docker/install_verilator.sh
+++ b/docker/install_verilator.sh
@@ -5,22 +5,22 @@ NPROC=4
 wget https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz -O gflags.tar.gz && \
 tar zxf gflags.tar.gz && cd gflags-2.2.2 && \
 cmake -DCMAKE_INSTALL_PREFIX=${THE_PREFIX} -DBUILD_SHARED_LIBS=ON \
-	-DCMAKE_BUILD_TYPE=Release && make -j${NPROC} install
+	-DCMAKE_BUILD_TYPE=Release && ${SUDO} make -j${NPROC} install
 cd ..
 
 # install glog
 wget https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz -O glog.tar.gz && \
 tar zxf glog.tar.gz && cd glog-0.6.0  && \
-cmake -DCMAKE_INSTALL_PREFIX=${THE_PREFIX} -DCMAKE_BUILD_TYPE=Release && make -j${NPROC} install
+cmake -DCMAKE_INSTALL_PREFIX=${THE_PREFIX} -DCMAKE_BUILD_TYPE=Release && ${SUDO} make -j${NPROC} install
 cd ..
 
 # install protobuf
 wget https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.9.tar.gz -O protobuf.tar.gz && \
 tar zxf protobuf.tar.gz && cd protobuf-21.9 && cd cmake && \
-cmake -DCMAKE_INSTALL_PREFIX=${THE_PREFIX} -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF && make -j${NPROC} install
+cmake -DCMAKE_INSTALL_PREFIX=${THE_PREFIX} -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF && ${SUDO} make -j${NPROC}
 cd ../..
 
 # install verilator
 wget https://github.com/verilator/verilator/archive/refs/tags/v4.228.tar.gz -O verilator.tar.gz && \
 tar zxf verilator.tar.gz && cd verilator-4.228 && \
-autoconf && ./configure --prefix=${THE_PREFIX} && make -j${NPROC} && make install
+autoconf && ./configure --prefix=${THE_PREFIX} && make -j${NPROC} && ${SUDO} make install

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,2 @@
+
+echo ${THE_PREFIX}


### PR DESCRIPTION
The Cmake with verilator now require verilator installed in github action to build.