### PR TITLE
Force user to provide the random policy

### DIFF
--- a/common/include/callback.h
+++ b/common/include/callback.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "abstract_random.h"
-#include <verilated.h>
 #include <functional>
+#include <verilated.h>
 
 class Callback {
 public:
@@ -13,22 +13,16 @@ public:
 template <typename SC_TYPE> class Driver : public Callback {
 public:
   // Write to DUT
-  using WriterFunc = ::std::function<void(const SC_TYPE&)>;
-  Driver(
-    CData &valid_,
-    const CData &ready_,
-    WriterFunc write_func_,
-    BoolPattern *new_random_policy_ = nullptr
-  )
-    : valid(valid_),
-      ready(ready_),
-      write_func(write_func_) {
-    SetRandomValidPolicy(new_random_policy_);
+  using WriterFunc = ::std::function<void(const SC_TYPE &)>;
+  Driver(CData &valid_, const CData &ready_, WriterFunc write_func_,
+         BoolPattern *random_policy_)
+      : valid(valid_), ready(ready_), write_func(write_func_),
+        random_policy(random_policy_) {
     valid = 0;
   }
 
-  void SetRandomValidPolicy(BoolPattern *new_random_policy_) {
-    random_policy.reset(new_random_policy_);
+  void SetRandomValidPolicy(BoolPattern *new_random_policy) {
+    random_policy.reset(new_random_policy);
   }
 
   void before_clk() override {
@@ -59,30 +53,22 @@ private:
   ::std::deque<SC_TYPE> q_source;
   ::std::unique_ptr<BoolPattern> random_policy;
   WriterFunc write_func;
-  bool GetRandom() {
-    return not random_policy or random_policy->operator()();
-  }
+  bool GetRandom() { return not random_policy or random_policy->operator()(); }
 };
 
 template <typename SC_TYPE> class Monitor : public Callback {
 public:
   // Read from DUT
   using ReaderFunc = ::std::function<SC_TYPE(void)>;
-  Monitor(
-    const CData &valid_,
-    CData &ready_,
-    ReaderFunc read_func_,
-    BoolPattern *new_random_policy_ = nullptr
-  )
-    : valid(valid_),
-      ready(ready_),
-      read_func(read_func_) {
-    SetRandomReadyPolicy(new_random_policy_);
+  Monitor(const CData &valid_, CData &ready_, ReaderFunc read_func_,
+          BoolPattern *random_policy_)
+      : valid(valid_), ready(ready_), read_func(read_func_),
+        random_policy(random_policy_) {
     ready = 1;
   }
 
-  void SetRandomReadyPolicy(BoolPattern *new_random_policy_) {
-    random_policy.reset(new_random_policy_);
+  void SetRandomReadyPolicy(BoolPattern *new_random_policy) {
+    random_policy.reset(new_random_policy);
   }
 
   void before_clk() {
@@ -99,7 +85,5 @@ private:
   ::std::deque<SC_TYPE> q_destination;
   ::std::unique_ptr<BoolPattern> random_policy;
   ReaderFunc read_func;
-  bool GetRandom() {
-    return not random_policy or random_policy->operator()();
-  }
+  bool GetRandom() { return not random_policy or random_policy->operator()(); }
 };

--- a/verilog/sim_two_power_mod.cpp
+++ b/verilog/sim_two_power_mod.cpp
@@ -1,5 +1,6 @@
 
 #include "Vtwo_power_mod.h"
+#include "abstract_random.h"
 #include "assign_port.h"
 #include "callback.h"
 #include "dut_wrapper.h"
@@ -43,10 +44,11 @@ public:
     dut_wrapper.clk(clk);
     driver = make_shared<Driver<RSATwoPowerModIn>>(
         dut_wrapper.dut->i_valid, dut_wrapper.dut->i_ready,
-        [this](const RSATwoPowerModIn &in) { this->writer(in); });
+        [this](const RSATwoPowerModIn &in) { this->writer(in); },
+        random_factory::AlwaysOne());
     monitor = make_shared<Monitor<RSATwoPowerModOut>>(
         dut_wrapper.dut->o_valid, dut_wrapper.dut->o_ready,
-        [this]() { return this->reader(); });
+        [this]() { return this->reader(); }, random_factory::AlwaysOne());
     dut_wrapper.register_callback(driver);
     dut_wrapper.register_callback(monitor);
 


### PR DESCRIPTION
Can user reset the unique_ptr to nullptr? If so, I think we will still check that unique_ptr is not null.