### PR TITLE
Use typedef in module interface

### DIFF
--- a/common/include/model_rsa.h
+++ b/common/include/model_rsa.h
@@ -5,13 +5,14 @@
 constexpr int kBW = 256;
 using KeyType = verilog::vuint<kBW>;
 struct RSATwoPowerModIn {
+  using TwoPowerMod_Power_t = verilog::vuint<32>;
   friend ::std::ostream &operator<<(::std::ostream &os,
                                     const RSATwoPowerModIn &v) {
     os << "{" << v.power << ", " << v.modulus << "}" << std::endl;
     return os;
   }
 
-  verilog::vuint<32> power;
+  TwoPowerMod_Power_t power;
   KeyType modulus;
 };
 using RSATwoPowerModOut = KeyType;

--- a/systemc/model_two_power_mod.cpp
+++ b/systemc/model_two_power_mod.cpp
@@ -61,7 +61,7 @@ SC_MODULE(Testbench) {
   }
 
   void Driver() {
-    verilog::vuint<32> power(512);
+    RSATwoPowerModIn::TwoPowerMod_Power_t power(512);
     KeyType modulus;
     cout << "calculate 2^: " << power << endl;
     cout << "modulus: " << str_modulus << endl;

--- a/verilog/sim_two_power_mod.cpp
+++ b/verilog/sim_two_power_mod.cpp
@@ -36,7 +36,8 @@ int sc_main(int, char **) {
   KeyType modulus;
   from_hex(modulus,
            "E07122F2A4A9E81141ADE518A2CD7574DCB67060B005E24665EF532E0CCA73E1");
-  testbench->push_input({.power = verilog::vuint<32>(512), .modulus = modulus});
+  testbench->push_input({.power = RSATwoPowerModIn::TwoPowerMod_Power_t(512),
+                         .modulus = modulus});
 
   TestBench_RsaTwoPowerMod::OutType golden;
   from_hex(golden,


### PR DESCRIPTION
Any good suggestion on the typedef naming rule?