### PR TITLE
Use struct in systemverilog implementation

### DIFF
--- a/verilog/RSA.sv
+++ b/verilog/RSA.sv
@@ -2,21 +2,19 @@
 import RSA_pkg::*;
 
 module RSA (
-	// input
-	input clk,
-	input rst,
+  // input
+  input clk,
+  input rst,
 
-	// input data
-	input i_valid,
-	output i_ready,
-	input KeyType i_msg,
-	input KeyType i_key,
-	input KeyType i_modulus,
+  // input data
+  input i_valid,
+  output i_ready,
+  input RSAModIn i_in,
 
-	// output data
-	output o_valid,
-	input o_ready,
-	output KeyType o_crypto
+  // output data
+  output o_valid,
+  input o_ready,
+  output RSAModOut o_out
 );
 
 typedef enum logic {
@@ -39,9 +37,6 @@ always_ff @(posedge clk or negedge rst) begin
     STATE_IDLE: begin
       if (i_valid) begin
         state <= STATE_WAITDONE;
-        msg <= i_msg;
-        key <= i_key;
-        modulus <= i_modulus;
         // kick start the two_power_mod
         two_power_mod_in_valid <= 1'b1;
       end
@@ -65,9 +60,9 @@ always_ff @( posedge clk or negedge rst ) begin
     two_power_mod_in_valid <= 0;
   end
   else if (state == STATE_IDLE && i_valid) begin
-    msg <= i_msg;
-    key <= i_key;
-    modulus <= i_modulus;
+    msg <= i_in.msg;
+    key <= i_in.key;
+    modulus <= i_in.modulus;
     // kick start the two_power_mod
     two_power_mod_in_valid <= 1'b1;
   end
@@ -125,7 +120,7 @@ RSAMont i_RSAMont (
   // output data
   .o_valid(o_valid),
   .o_ready(o_ready),
-  .o_crypto(o_crypto)
+  .o_crypto(o_out)
 );
 
 endmodule

--- a/verilog/RSA.sv
+++ b/verilog/RSA.sv
@@ -86,6 +86,8 @@ KeyType packed_val;
 
 logic packed_valid;
 logic packed_ready;
+IntType power;
+assign power = MOD_WIDTH * 2;
 
 RSATwoPowerMod i_two_power_mod (
   // input
@@ -95,8 +97,7 @@ RSATwoPowerMod i_two_power_mod (
   // input data
   .i_valid(two_power_mod_in_valid),
   .i_ready(two_power_mod_in_ready),
-  .i_modulus(modulus),
-  .i_power(MOD_WIDTH * 2),
+  .i_in({power, modulus}),
 
   // output data
   .o_valid(packed_valid),

--- a/verilog/RSA256_sim.cpp
+++ b/verilog/RSA256_sim.cpp
@@ -19,14 +19,12 @@ public:
   using TestBench::TestBench;
 
   void writer(const InType &in) {
-    write_verilator_port(dut_wrapper.dut->i_msg, in.msg);
-    write_verilator_port(dut_wrapper.dut->i_key, in.key);
-    write_verilator_port(dut_wrapper.dut->i_modulus, in.modulus);
+    write_verilator_port(dut_wrapper.dut->i_in, verilog::pack(in));
   }
 
   OutType reader() {
     OutType out;
-    read_verilator_port(out, dut_wrapper.dut->o_crypto);
+    read_verilator_port(out, dut_wrapper.dut->o_out);
     return out;
   }
 };

--- a/verilog/RSAMont.sv
+++ b/verilog/RSAMont.sv
@@ -186,9 +186,7 @@ RSAMontgomery i_montgomery(
   // input data
   .i_valid(loop_ovalid),
   .i_ready(loop_oready),
-  .i_a(montgomery_in_a),
-  .i_b(montgomery_in_b),
-  .i_modulus(modulus),
+  .i_in({montgomery_in_a, montgomery_in_b, modulus}),
 
   // output data
   .o_valid(montgomery_out_valid),

--- a/verilog/RSAMontgomery.sv
+++ b/verilog/RSAMontgomery.sv
@@ -10,14 +10,12 @@ module RSAMontgomery #(
 	// input data
 	input i_valid,
 	output i_ready,
-	input KeyType i_a,
-	input KeyType i_b,
-	input KeyType i_modulus,
+	input RSAMontgomeryModIn i_in,
 
 	// output data
 	output o_valid,
 	input o_ready,
-	output KeyType o_out
+	output RSAMontgomeryModOut o_out
 );
 
 typedef logic [MOD_WIDTH + 2 - 1:0] ExtendKeyType;
@@ -66,35 +64,35 @@ always_comb begin
     if (round_counter == MOD_WIDTH-1) begin
       state_next = STATE_WAITDONE;
     end
-	end
-	STATE_WAITDONE: begin
-		if (o_ready) begin
-			state_next = STATE_IDLE;
-		end
-	end
-	default: begin
-		state_next = STATE_IDLE;
-	end
+  end
+  STATE_WAITDONE: begin
+    if (o_ready) begin
+      state_next = STATE_IDLE;
+    end
+  end
+  default: begin
+    state_next = STATE_IDLE;
+  end
   endcase
 end
 
 // read input data
 always_ff @( posedge clk or negedge rst ) begin
   if (!rst) begin
-		data_a <= 0;
-		data_b <= 0;
-		data_modulus <= 0;
+    data_a <= 0;
+    data_b <= 0;
+    data_modulus <= 0;
   end
   else begin
-		if (i_ready && i_valid) begin
-			data_a <= {2'b0, i_a};
-			data_b <= {2'b0, i_b};
-			data_modulus <= {2'b0, i_modulus};
-		end else begin
-			data_a <= data_a;
-			data_b <= data_b;
-			data_modulus <= data_modulus;
-		end
+    if (i_ready && i_valid) begin
+      data_a <= {2'b0, i_in.a};
+      data_b <= {2'b0, i_in.b};
+      data_modulus <= {2'b0, i_in.modulus};
+    end else begin
+      data_a <= data_a;
+      data_b <= data_b;
+      data_modulus <= data_modulus;
+    end
   end
 end
 
@@ -104,12 +102,12 @@ always_ff @(posedge clk or negedge rst) begin
     round_counter <= 0;
   end
   else begin
-	case (state)
-		STATE_CALCULATE:
-			round_counter <= round_counter + 1;
-		default:
-		round_counter <= 0;
-	endcase
+  case (state)
+    STATE_CALCULATE:
+      round_counter <= round_counter + 1;
+    default:
+    round_counter <= 0;
+  endcase
   end
 end
 
@@ -119,30 +117,30 @@ always_ff @(posedge clk or negedge rst) begin
     round_result <= 0;
   end
   else begin
-		round_result <= round_result_next;
-	end
+    round_result <= round_result_next;
+  end
 end
 
 always_comb begin
   case (state)
   STATE_IDLE: begin
-		round_result_next = 0;
+    round_result_next = 0;
   end
   STATE_CALCULATE: begin
-		if (data_a[round_counter]) begin
-			round_result_next = round_result + data_b;
-		end
-		if (round_result_next[0]) begin
-			round_result_next += data_modulus;
-		end
-		round_result_next >>= 1;
-	end
-	STATE_WAITDONE: begin
-		round_result_next = round_result;
-	end
-	default: begin
-		round_result_next = 0;
-	end
+    if (data_a[round_counter]) begin
+      round_result_next = round_result + data_b;
+    end
+    if (round_result_next[0]) begin
+      round_result_next += data_modulus;
+    end
+    round_result_next >>= 1;
+  end
+  STATE_WAITDONE: begin
+    round_result_next = round_result;
+  end
+  default: begin
+    round_result_next = 0;
+  end
   endcase
 end
 

--- a/verilog/RSAMontgomery_sim.cpp
+++ b/verilog/RSAMontgomery_sim.cpp
@@ -19,9 +19,7 @@ public:
   using TestBench::TestBench;
 
   void writer(const InType &in) {
-    write_verilator_port(dut_wrapper.dut->i_a, in.a);
-    write_verilator_port(dut_wrapper.dut->i_b, in.b);
-    write_verilator_port(dut_wrapper.dut->i_modulus, in.modulus);
+    write_verilator_port(dut_wrapper.dut->i_in, verilog::pack(in));
   }
 
   OutType reader() {

--- a/verilog/RSATwoPowerMod_sim.cpp
+++ b/verilog/RSATwoPowerMod_sim.cpp
@@ -19,8 +19,7 @@ public:
   using TestBench::TestBench;
 
   virtual void writer(const InType &in) {
-    write_verilator_port(dut_wrapper.dut->i_power, in.power);
-    write_verilator_port(dut_wrapper.dut->i_modulus, in.modulus);
+    write_verilator_port(dut_wrapper.dut->i_in, verilog::pack(in));
   };
 
   virtual OutType reader() {

--- a/verilog/RSA_pkg.sv
+++ b/verilog/RSA_pkg.sv
@@ -7,20 +7,20 @@ typedef logic [MOD_WIDTH-1:0] KeyType;
 
 typedef logic [INT_WIDTH-1:0] IntType;
 
-typedef struct {
+typedef struct packed {
   KeyType msg;
   KeyType key;
   KeyType modulus;
 } RSAModIn;
 typedef KeyType RSAModOut;
 
-typedef struct {
+typedef struct packed {
   IntType power;
   KeyType modulus;
 } RSATwoPowerModIn;
 typedef KeyType RSATwoPowerModOut;
 
-typedef struct {
+typedef struct packed {
   KeyType a;
   KeyType b;
   KeyType modulus;


### PR DESCRIPTION
Using struct basically make testbench implementation easier.
The write_verilator_port becomes identical:
```c++
write_verilator_port(dut_wrapper.dut->in, verilog::pack(in));
```