### PR TITLE
Fix testbench

### DIFF
--- a/verilog/RSA256_sim.cpp
+++ b/verilog/RSA256_sim.cpp
@@ -50,6 +50,5 @@ int sc_main(int, char **) {
   RSAModOut ans;
   from_hex(ans, str_ans);
   testbench->push_golden(ans);
-  testbench->run(160 * 1000, SC_NS);
-  return 0;
+  return testbench->run(180 * 1000, SC_NS);
 }

--- a/verilog/RSAMontgomery_sim.cpp
+++ b/verilog/RSAMontgomery_sim.cpp
@@ -48,6 +48,5 @@ int sc_main(int, char **) {
            "1ECC89942DF6DD65E01D20F2AC49F495CB47F0EA9977351FD92DD3F8FD4B33D7");
   testbench->push_golden(golden);
 
-  testbench->run(1200, SC_NS);
-  return 0;
+  return testbench->run(1200, SC_NS);
 }

--- a/verilog/RSATwoPowerMod_sim.cpp
+++ b/verilog/RSATwoPowerMod_sim.cpp
@@ -43,6 +43,5 @@ int sc_main(int, char **) {
            "0AF39E1F831CB4FCD92B17F61F473735C687593A931C97D2B60AD6C7443F09FDB");
   testbench->push_golden(golden);
 
-  testbench->run(1200, SC_NS);
-  return 0;
+  return testbench->run(1200, SC_NS);
 }

--- a/vtuber/scoreboard.h
+++ b/vtuber/scoreboard.h
@@ -9,7 +9,7 @@ template <typename DataType> class ScoreBoard {
 private:
 public:
   ScoreBoard(::std::function<void()> RaiseFailure_)
-      : RaiseFailure(RaiseFailure_) {
+      : RaiseFailure(RaiseFailure_), pass(true) {
     assert(RaiseFailure);
   };
   ~ScoreBoard() = default;
@@ -19,6 +19,7 @@ public:
     check();
   }
   void push_received(const DataType &data) {
+    DLOG(INFO) << "Receive Verilog Out: " << data;
     receiveds.push_back(data);
     check();
   }
@@ -31,6 +32,7 @@ public:
       if (golden == received) {
       } else {
         LOG(ERROR) << "Golden != Verilog Out: " << golden << " vs " << received;
+        pass = false;
         RaiseFailure();
       }
       goldens.pop_front();
@@ -38,10 +40,11 @@ public:
     }
   }
 
-  bool is_pass() { return goldens.empty() && receiveds.empty(); }
+  bool is_pass() { return pass && goldens.empty() && receiveds.empty(); }
 
 private:
   ::std::deque<DataType> goldens;
   ::std::deque<DataType> receiveds;
   ::std::function<void()> RaiseFailure;
+  bool pass;
 };

--- a/vtuber/testbench.h
+++ b/vtuber/testbench.h
@@ -4,6 +4,7 @@
 #include "dut_wrapper.h"
 #include "scoreboard.h"
 
+#include <glog/logging.h>
 #include <memory>
 #include <systemc>
 
@@ -41,11 +42,12 @@ public:
     dut_wrapper.register_callback(monitor);
   }
 
-  void run(int duration, sc_time_unit unit) {
+  int run(int duration, sc_time_unit unit) {
     sc_start(duration, unit);
     if (!score_board->is_pass()) {
       LOG(ERROR) << "Score board result mismatch" << endl;
     }
+    return !score_board->is_pass();
   }
 
   void push_input(const InType &in) { driver->push_back(in); }


### PR DESCRIPTION
Get an implementation that has the best waveform output:
## Driver:
Before:
<img width="611" alt="before" src="https://user-images.githubusercontent.com/1913143/222095140-e7d31454-492c-4b1e-8c8b-3082a75ba78d.png">
At the positive edge of clk at 3 ps, since the valid is pulled up in the function "before_clk", so at positive edge of clk, the device receives a valid transaction and pulls down the ready. Also, since ready has already been pulled down at the clk posedge, the Driver has no change to pull down the valid after transaction.

After:
<img width="670" alt="after" src="https://user-images.githubusercontent.com/1913143/222094336-0b27e2db-0949-4e02-81a9-c5565270d646.png">
After the fix
1. The ready signal will wait valid signal for one cycle,
2. The valid signal can detect the transaction so it will pull down after the transaction.