### PR TITLE
Add line source header

### DIFF
--- a/vtuber/source.h
+++ b/vtuber/source.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+template <typename T> class Source {
+public:
+  Source() {}
+  virtual ~Source() = default;
+  virtual ::std::vector<T> get() = 0;
+};
+
+template <typename T> class VintLineSource : public Source<T> {
+  static_assert(verilog::is_vint_v<T>,
+                "T must be a vint type, not array, struct, or union");
+
+public:
+  VintLineSource(const ::std::string &filename_) : Source<T>() {
+    filename = filename_;
+  }
+
+  ::std::vector<T> get() override {
+    ::std::vector<T> data;
+    ::std::string line;
+    ::std::ifstream inputFile(filename);
+    while (std::getline(inputFile, line)) {
+      T t(line, 16);
+      data.push_back(t);
+    }
+    inputFile.close();
+    return data;
+  }
+
+private:
+  ::std::string filename;
+};


### PR DESCRIPTION
This is a template that can read vint from a files. Right now only read vint line by line is supported.
I think there are things can be done:
1. match source with command line argument that user can dynamically replace test data.
2. Support only general data format, like json, binary json or [message pack](https://msgpack.org/)