### PR TITLE
Add period setting in dut_wrapper

### DIFF
--- a/verilog/RSA256_sim.cpp
+++ b/verilog/RSA256_sim.cpp
@@ -71,5 +71,5 @@ int sc_main(int, char **) {
   // sample out
   RSAModOut ans(str_ans);
   testbench->push_golden(ans);
-  return testbench->run(180, SC_US);
+  return testbench->run(400, SC_US);
 }

--- a/verilog/RSAMontgomery_sim.cpp
+++ b/verilog/RSAMontgomery_sim.cpp
@@ -64,5 +64,5 @@ int sc_main(int, char **) {
       "1ECC89942DF6DD65E01D20F2AC49F495CB47F0EA9977351FD92DD3F8FD4B33D7");
   testbench->push_golden(golden);
 
-  return testbench->run(1200, SC_NS);
+  return testbench->run(3, SC_US);
 }

--- a/verilog/RSATwoPowerMod_sim.cpp
+++ b/verilog/RSATwoPowerMod_sim.cpp
@@ -63,5 +63,5 @@ int sc_main(int, char **) {
       "0AF39E1F831CB4FCD92B17F61F473735C687593A931C97D2B60AD6C7443F09FDB");
   testbench->push_golden(golden);
 
-  return testbench->run(1200, SC_NS);
+  return testbench->run(3, SC_US);
 }

--- a/vtuber/bridge/verilator/dut_wrapper.h
+++ b/vtuber/bridge/verilator/dut_wrapper.h
@@ -15,6 +15,7 @@ using namespace sc_core;
 
 template <typename DUT> SC_MODULE(DUTWrapper) {
 public:
+  const unsigned period_ps = 2;
   vector<shared_ptr<Connector<DUT>>> connectors;
   bool dump_waveform;
 
@@ -64,15 +65,15 @@ public:
     Step();
 
     // pull down the reset value
-    ctx->timeInc(1);
+    ctx->timeInc(period_ps);
     dut->rst = 0;
     Step();
 
-    ctx->timeInc(1);
+    ctx->timeInc(period_ps);
     dut->rst = 1;
     Step();
 
-    ctx->timeInc(1);
+    ctx->timeInc(period_ps);
   }
 
   void Executor() {
@@ -95,12 +96,12 @@ public:
       if (dump_waveform) {
         tfp->dump(ctx->time());
       }
-      ctx->timeInc(1);
+      ctx->timeInc(period_ps);
 
       // negtive edge of clk
       dut->clk = false;
       Step();
-      ctx->timeInc(1);
+      ctx->timeInc(period_ps);
     }
   }
 


### PR DESCRIPTION
I inspect this issue when debug waveform using gtkwave.
On windows, the zoom in of gtkwave has a maximum ratio. In RSA implementation, the input data of 256 bits are too long that even in maximum ratio the data cannot fully show. To cope with this issue, I set simulated clock a longer period.
This change twice the period of clock, and make the period a constant in `dut_wrapper`. Later we can make this argument to constructor.
