### PR TITLE
Add unpack disabled test for varray and vstruct

### DIFF
--- a/vtuber/verilog/dtype/varray_test.cpp
+++ b/vtuber/verilog/dtype/varray_test.cpp
@@ -9,62 +9,89 @@
 // Other libraries' .h files.
 #include <gtest/gtest.h>
 // Your project's .h files.
-#include "verilog/operation/pack.h"
-#include "verilog/operation/bits.h"
-#include "verilog/dtype/vint.h"
 #include "verilog/dtype/varray.h"
+#include "verilog/dtype/vint.h"
+#include "verilog/operation/bits.h"
+#include "verilog/operation/pack.h"
+#include "verilog/operation/unpack.h"
 using namespace std;
 using namespace verilog;
 typedef varray<vuint<10>, 5> Arr1;
 typedef varray<vuint<3>, 2, 3> Arr2;
 
 TEST(TestVerilogArray, Basic) {
-	Arr1 v10x5;
-	Arr2 v3x2x3;
-	static_assert(bits<Arr1>() == 50);
-	static_assert(bits<Arr2>() == 18);
-	static_assert(Arr1::asize == 5);
-	static_assert(Arr2::asize == 6);
-	static_assert(is_varray_v<Arr1>);
-	static_assert(is_varray_v<Arr2>);
+  Arr1 v10x5;
+  Arr2 v3x2x3;
+  static_assert(bits<Arr1>() == 50);
+  static_assert(bits<Arr2>() == 18);
+  static_assert(Arr1::asize == 5);
+  static_assert(Arr2::asize == 6);
+  static_assert(is_varray_v<Arr1>);
+  static_assert(is_varray_v<Arr2>);
 
-	{
-		auto it = v10x5.begin();
-		auto it_end = v10x5.end();
-		for (unsigned i = 0; i < Arr1::asize; ++i, ++it) {
-			*it = i;
-		}
-		EXPECT_EQ(v10x5[0], 0);
-		EXPECT_EQ(v10x5[1], 1);
-		EXPECT_EQ(v10x5[2], 2);
-		EXPECT_EQ(v10x5[3], 3);
-		EXPECT_EQ(v10x5[4], 4);
-		EXPECT_EQ(it, it_end);
-	}
-	{
-		auto it = v3x2x3.begin();
-		auto it_end = v3x2x3.end();
-		for (unsigned i = 0; i < Arr2::asize; ++i, ++it) {
-			*it = i;
-		}
-		EXPECT_EQ(v3x2x3[0][0], 0);
-		EXPECT_EQ(v3x2x3[0][1], 1);
-		EXPECT_EQ(v3x2x3[0][2], 2);
-		EXPECT_EQ(v3x2x3[1][0], 3);
-		EXPECT_EQ(v3x2x3[1][1], 4);
-		EXPECT_EQ(v3x2x3[1][2], 5);
-		EXPECT_EQ(it, it_end);
-	}
+  {
+    auto it = v10x5.begin();
+    auto it_end = v10x5.end();
+    for (unsigned i = 0; i < Arr1::asize; ++i, ++it) {
+      *it = i;
+    }
+    EXPECT_EQ(v10x5[0], 0);
+    EXPECT_EQ(v10x5[1], 1);
+    EXPECT_EQ(v10x5[2], 2);
+    EXPECT_EQ(v10x5[3], 3);
+    EXPECT_EQ(v10x5[4], 4);
+    EXPECT_EQ(it, it_end);
+  }
+  {
+    auto it = v3x2x3.begin();
+    auto it_end = v3x2x3.end();
+    for (unsigned i = 0; i < Arr2::asize; ++i, ++it) {
+      *it = i;
+    }
+    EXPECT_EQ(v3x2x3[0][0], 0);
+    EXPECT_EQ(v3x2x3[0][1], 1);
+    EXPECT_EQ(v3x2x3[0][2], 2);
+    EXPECT_EQ(v3x2x3[1][0], 3);
+    EXPECT_EQ(v3x2x3[1][1], 4);
+    EXPECT_EQ(v3x2x3[1][2], 5);
+    EXPECT_EQ(it, it_end);
+  }
 }
 
 TEST(TestVerilogArray, Pack) {
-	Arr2 v3x2x3;
-	v3x2x3[0][0] = 0;
-	v3x2x3[0][1] = 1;
-	v3x2x3[0][2] = 2;
-	v3x2x3[1][0] = 3;
-	v3x2x3[1][1] = 4;
-	v3x2x3[1][2] = 5;
-	vuint<18> tmps = pack(v3x2x3);
-	EXPECT_EQ(tmps, 0012345);
+  Arr2 v3x2x3;
+  v3x2x3[0][0] = 0;
+  v3x2x3[0][1] = 1;
+  v3x2x3[0][2] = 2;
+  v3x2x3[1][0] = 3;
+  v3x2x3[1][1] = 4;
+  v3x2x3[1][2] = 5;
+  vuint<18> tmps = pack(v3x2x3);
+  EXPECT_EQ(tmps, 0012345);
+}
+
+TEST(TestVerilogArray, DISABLED_Unpack) {
+  vuint<256> v256;
+  from_hex(v256, "D1798A3C'8326770B'91643739'7AB540E3'D21345C7'539C5996'"
+                 "F9ADDDCF'A45F1DFE");
+  {
+    varray<vuint<32>, 8> a32_8;
+    // unpack(a32_8, v256);
+    EXPECT_EQ(a32_8[0].value(), 0xD1798A3C);
+    EXPECT_EQ(a32_8[1].value(), 0x8326770B);
+    EXPECT_EQ(a32_8[2].value(), 0x91643739);
+    EXPECT_EQ(a32_8[3].value(), 0x7AB540E3);
+    EXPECT_EQ(a32_8[4].value(), 0xD21345C7);
+    EXPECT_EQ(a32_8[5].value(), 0x539C5996);
+    EXPECT_EQ(a32_8[6].value(), 0xF9ADDDCF);
+    EXPECT_EQ(a32_8[7].value(), 0xA45F1DFE);
+  }
+  {
+    varray<vuint<64>, 4> a64_4;
+    // unpack(a64_4, v256);
+    EXPECT_EQ(a64_4[0].value(), 0xD1798A3C8326770B);
+    EXPECT_EQ(a64_4[1].value(), 0x916437397AB540E3);
+    EXPECT_EQ(a64_4[2].value(), 0xD21345C7539C5996);
+    EXPECT_EQ(a64_4[3].value(), 0xF9ADDDCFA45F1DFE);
+  }
 }

--- a/vtuber/verilog/dtype/varray_test.cpp
+++ b/vtuber/verilog/dtype/varray_test.cpp
@@ -70,13 +70,13 @@ TEST(TestVerilogArray, Pack) {
   EXPECT_EQ(tmps, 0012345);
 }
 
-TEST(TestVerilogArray, DISABLED_Unpack) {
+TEST(TestVerilogArray, Unpack) {
   vuint<256> v256;
   from_hex(v256, "D1798A3C'8326770B'91643739'7AB540E3'D21345C7'539C5996'"
                  "F9ADDDCF'A45F1DFE");
   {
     varray<vuint<32>, 8> a32_8;
-    // unpack(a32_8, v256);
+    unpack(a32_8, v256);
     EXPECT_EQ(a32_8[0].value(), 0xD1798A3C);
     EXPECT_EQ(a32_8[1].value(), 0x8326770B);
     EXPECT_EQ(a32_8[2].value(), 0x91643739);
@@ -88,7 +88,7 @@ TEST(TestVerilogArray, DISABLED_Unpack) {
   }
   {
     varray<vuint<64>, 4> a64_4;
-    // unpack(a64_4, v256);
+    unpack(a64_4, v256);
     EXPECT_EQ(a64_4[0].value(), 0xD1798A3C8326770B);
     EXPECT_EQ(a64_4[1].value(), 0x916437397AB540E3);
     EXPECT_EQ(a64_4[2].value(), 0xD21345C7539C5996);

--- a/vtuber/verilog/dtype/vstruct_test.cpp
+++ b/vtuber/verilog/dtype/vstruct_test.cpp
@@ -23,6 +23,13 @@ struct S1 {
 	VSTRUCT_HAS_PROCESS(S1)
 };
 
+struct rS1 {
+	vuint<3> member1;
+	Arr2     member2;
+	MAKE_VSTRUCT(member1, member2)
+	VSTRUCT_HAS_PROCESS(rS1)
+};
+
 TEST(TestVerilogStruct, Pack) {
 	S1 s1;
 	static_assert(is_vstruct_v<S1>);
@@ -36,6 +43,33 @@ TEST(TestVerilogStruct, Pack) {
 	s1.member2 = 0;
 	vuint<21> tmp = pack(s1);
 	EXPECT_EQ(tmp, 06543210);
+}
+
+TEST(TestVerilogStruct, DISABLED_Unpack) {
+	vuint<21> v21;
+	v21 = 0x57B3DC;
+	{
+		S1 s1;
+		// unpack(s1, v21);
+		EXPECT_EQ(s1.member1[0][0], 05);
+		EXPECT_EQ(s1.member1[0][1], 07);
+		EXPECT_EQ(s1.member1[0][2], 03);
+		EXPECT_EQ(s1.member1[1][0], 01);
+		EXPECT_EQ(s1.member1[1][1], 07);
+		EXPECT_EQ(s1.member1[1][2], 03);
+		EXPECT_EQ(s1.member2, 04);
+	}
+	{
+		rS1 s1;
+		// unpack(s1, v21);
+		EXPECT_EQ(s1.member1, 05);
+		EXPECT_EQ(s1.member2[0][0], 07);
+		EXPECT_EQ(s1.member2[0][1], 03);
+		EXPECT_EQ(s1.member2[0][2], 01);
+		EXPECT_EQ(s1.member2[1][0], 07);
+		EXPECT_EQ(s1.member2[1][1], 03);
+		EXPECT_EQ(s1.member2[1][2], 04);
+	}
 }
 
 typedef varray<vuint<64>, 5> Arr3;

--- a/vtuber/verilog/dtype/vstruct_test.cpp
+++ b/vtuber/verilog/dtype/vstruct_test.cpp
@@ -45,30 +45,30 @@ TEST(TestVerilogStruct, Pack) {
 	EXPECT_EQ(tmp, 06543210);
 }
 
-TEST(TestVerilogStruct, DISABLED_Unpack) {
+TEST(TestVerilogStruct, Unpack) {
 	vuint<21> v21;
 	v21 = 0x57B3DC;
 	{
 		S1 s1;
-		// unpack(s1, v21);
-		EXPECT_EQ(s1.member1[0][0], 05);
-		EXPECT_EQ(s1.member1[0][1], 07);
-		EXPECT_EQ(s1.member1[0][2], 03);
-		EXPECT_EQ(s1.member1[1][0], 01);
-		EXPECT_EQ(s1.member1[1][1], 07);
-		EXPECT_EQ(s1.member1[1][2], 03);
-		EXPECT_EQ(s1.member2, 04);
+		unpack(s1, v21);
+		EXPECT_EQ(s1.member1[0][0], 0x5);
+		EXPECT_EQ(s1.member1[0][1], 0x7);
+		EXPECT_EQ(s1.member1[0][2], 0x3);
+		EXPECT_EQ(s1.member1[1][0], 0x1);
+		EXPECT_EQ(s1.member1[1][1], 0x7);
+		EXPECT_EQ(s1.member1[1][2], 0x3);
+		EXPECT_EQ(s1.member2, 0x4);
 	}
 	{
 		rS1 s1;
-		// unpack(s1, v21);
-		EXPECT_EQ(s1.member1, 05);
-		EXPECT_EQ(s1.member2[0][0], 07);
-		EXPECT_EQ(s1.member2[0][1], 03);
-		EXPECT_EQ(s1.member2[0][2], 01);
-		EXPECT_EQ(s1.member2[1][0], 07);
-		EXPECT_EQ(s1.member2[1][1], 03);
-		EXPECT_EQ(s1.member2[1][2], 04);
+		unpack(s1, v21);
+		EXPECT_EQ(s1.member1, 0x5);
+		EXPECT_EQ(s1.member2[0][0], 0x7);
+		EXPECT_EQ(s1.member2[0][1], 0x3);
+		EXPECT_EQ(s1.member2[0][2], 0x1);
+		EXPECT_EQ(s1.member2[1][0], 0x7);
+		EXPECT_EQ(s1.member2[1][1], 0x3);
+		EXPECT_EQ(s1.member2[1][2], 0x4);
 	}
 }
 

--- a/vtuber/verilog/operation/unpack.h
+++ b/vtuber/verilog/operation/unpack.h
@@ -6,3 +6,88 @@
 // Other libraries' .h files.
 // Your project's .h files.
 #include "verilog/dtype_base.h"
+#include "verilog/operation/bits.h"
+#include "verilog/operation/bit_offset.h"
+
+namespace verilog {
+
+namespace detail {
+
+///////////////////
+// analog to verilog {>>{}} (unpacking)
+// an abstraction layer to unpack a datatype
+// also put forward declaration here
+///////////////////
+template<typename T, unsigned num_bit>
+void unpack_nocheck(T& t, const vint<false, num_bit> u);
+
+// need forward declaration since there might be nested vuint/array/struct/union
+template<typename T, unsigned num_bit, unsigned ...i>
+void varray_unpack(
+	T& t, const vint<false, num_bit> u,
+	::std::integer_sequence<unsigned, i...> idx
+);
+template<typename T, unsigned num_bit, unsigned ...i>
+void vstruct_unpack(
+	T& t, const vint<false, num_bit> u,
+	::std::integer_sequence<unsigned, i...> idx
+);
+// template<typename T, unsigned num_bit, unsigned ...i>
+// void vunion_unpack(
+// 	const vint<num_bit, false> u, T& t,
+// 	::std::integer_sequence<unsigned, i...> idx
+// );
+
+template<typename T, unsigned num_bit, unsigned ...i>
+void varray_unpack(
+	T& t, const vint<false, num_bit> u,
+	::std::integer_sequence<unsigned, i...> idx
+) {
+	constexpr unsigned num_bit_element = bits_v<typename T::dtype>;
+	typename T::dtype* t_ptr = t.begin();
+	((
+		unpack_nocheck(
+			t_ptr[i],
+			u.template Slice<(T::asize-1-i)*num_bit_element, num_bit_element>()
+		)
+	),...);
+}
+
+template<typename T, unsigned num_bit, unsigned ...i>
+void vstruct_unpack(
+	T& t, const vint<false, num_bit> u,
+	::std::integer_sequence<unsigned, i...> idx
+) {
+	((
+		unpack_nocheck(
+			t.template get<i>(),
+			u.template Slice<
+				bit_offset_first_member_at_msb_v<T, i>,
+				bits_v<decltype(t.template get<i>())>
+			>()
+		)
+	),...);
+}
+
+template<typename T, unsigned num_bit>
+void unpack_nocheck(T& t, const vint<false, num_bit> u) {
+	static_assert(is_dtype_v<T>, "T must be a verilog type");
+	if constexpr (is_vint_v<T>) {
+		t = u;
+	} else if constexpr (is_varray_v<T>) {
+		detail::varray_unpack<T>(t, u, ::std::make_integer_sequence<unsigned, T::asize>());
+	} else if constexpr (is_vstruct_v<T>) {
+		detail::vstruct_unpack<T>(t, u, ::std::make_integer_sequence<unsigned, T::num_members>());
+//	} else if constexpr (is_vunion_v<T>) {
+	}
+}
+
+} // namespace detail
+
+template<typename T, unsigned num_bit>
+void unpack(T& t, const vint<false, num_bit>& u) {
+	static_assert(bits_v<T> == num_bit, "Unpack and vint must have the same bitwidth");
+	detail::unpack_nocheck(t, u);
+}
+
+} // namespace verilog


### PR DESCRIPTION
@johnjohnlin 
It comes to me that unpack should support only varray and vstruct.
The unpack for vint will encounter problem that:
1. The interface, do we need to support variable number of vint in function argument?
2. The unpack to vint can be done by Slice to the packed value.
