### PR TITLE
Add from_bytes/to_bytes functions

### DIFF
--- a/vtuber/verilog/dtype/vint_test.cpp
+++ b/vtuber/verilog/dtype/vint_test.cpp
@@ -373,6 +373,46 @@ TEST(TestVerilogSigned, ToHex) {
 }
 
 ///////////////////////////
+// Test from bytes array
+///////////////////////////
+template<template<unsigned> class IntTmpl>
+void FromBytesTemplate() {
+	uint8_t b8[] = {0x5A};
+	uint8_t b16[] = {0xA5, 0x5A};
+	uint8_t b32[] = {0x87, 0x65, 0x43, 0x21};
+	uint8_t b128[] = {0xc3, 0x71, 0x5f, 0x07, 0x9b, 0xca, 0x23, 0x4f, 0xd7, 0x59, 0x8c, 0x70, 0x00, 0x1b, 0xc5, 0x3c};
+	IntTmpl<8> v8;
+	// from_bytes(v8, b8, 1);
+	EXPECT_EQ(v8.v[0], 0x5A);
+	// Assign value from start of bytes array
+	// from_bytes(v8, b16, 1);
+	EXPECT_EQ(v8.v[0], 0xA5);
+
+	IntTmpl<13> v13;
+	// from_bytes(v13, b16, 2);
+	EXPECT_EQ(v13.v[0], 0x55A);
+	// from_bytes(v13, b32, 3);
+	EXPECT_EQ(v13.v[0], 0x765);
+
+	IntTmpl<127> v127;
+	// from_bytes(v127, b128, 16);
+	EXPECT_EQ(v127.v[0], 0x43715f079bca234fllu);
+	EXPECT_EQ(v127.v[1], 0xd7598c70001bc53cllu);
+}
+
+TEST(TestVerilogUnsigned, DISABLED_FromBytes) {
+	FromBytesTemplate<vuint>();
+}
+
+TEST(TestVerilogSigned, DISABLED_FromBytes) {
+	FromBytesTemplate<vsint>();
+}
+
+///////////////////////////
+// Test to bytes array
+///////////////////////////
+
+///////////////////////////
 // Test comparison
 // NOTE: This test is more difficult than others, it mixes more arith, assign...
 ///////////////////////////

--- a/vtuber/verilog/dtype/vint_test.cpp
+++ b/vtuber/verilog/dtype/vint_test.cpp
@@ -411,6 +411,70 @@ TEST(TestVerilogSigned, DISABLED_FromBytes) {
 ///////////////////////////
 // Test to bytes array
 ///////////////////////////
+template<template<unsigned> class IntTmpl>
+void ToBytesTemplate() {
+	uint8_t b8[1] = {0xff};
+	uint8_t b16[2] = {0xff, 0xff};
+	uint8_t b32[4] = {0xff, 0xff, 0xff, 0xff};
+	uint8_t b128[16] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+	IntTmpl<8> v8;
+	v8.v[0] = 0x2a;
+	v8.ClearUnusedBits();
+	// to_bytes(b8, 1, v8);
+	EXPECT_EQ(b8[0], 0x2A);
+
+	// to_bytes(b16, 2, v8);   // Align on LSB if bytes is longer
+	EXPECT_EQ(b16[1], 0x0);
+	EXPECT_EQ(b16[0], 0x2A);
+
+	IntTmpl<13> v13;
+	v13.v[0] = 0x1a2a;
+	v13.ClearUnusedBits();
+	// to_bytes(b8, 1, v13);
+	EXPECT_EQ(b8[0], 0x2A);
+
+	// to_bytes(b16, 2, v13);
+	EXPECT_EQ(b16[1], 0x1A);
+	EXPECT_EQ(b16[0], 0x2A);
+
+	IntTmpl<66> v66;
+	v66.v[1] = 0x2;
+	v66.v[0] = 0x0123456789abcdefllu;
+	v66.ClearUnusedBits();
+	// to_bytes(b32, 4, v66);
+	EXPECT_EQ(b32[3], 0x89);
+	EXPECT_EQ(b32[2], 0xab);
+	EXPECT_EQ(b32[1], 0xcd);
+	EXPECT_EQ(b32[0], 0xef);
+
+	// to_bytes(b128, 16, v66)
+	EXPECT_EQ(b32[15], 0x00);
+	EXPECT_EQ(b32[14], 0x00);
+	EXPECT_EQ(b32[13], 0x00);
+	EXPECT_EQ(b32[12], 0x00);
+	EXPECT_EQ(b32[11], 0x00);
+	EXPECT_EQ(b32[10], 0x00);
+	EXPECT_EQ(b32[9], 0x00);
+	EXPECT_EQ(b32[8], 0x02);
+	EXPECT_EQ(b32[7], 0x01);
+	EXPECT_EQ(b32[6], 0x23);
+	EXPECT_EQ(b32[5], 0x45);
+	EXPECT_EQ(b32[4], 0x67);
+	EXPECT_EQ(b32[3], 0x89);
+	EXPECT_EQ(b32[2], 0xab);
+	EXPECT_EQ(b32[1], 0xcd);
+	EXPECT_EQ(b32[0], 0xef);
+}
+
+TEST(TestVerilogUnsigned, ToBytes) {
+	ToHexTemplate<vuint>();
+}
+
+TEST(TestVerilogSigned, ToBytes) {
+	ToHexTemplate<vsint>();
+}
+
 
 ///////////////////////////
 // Test comparison


### PR DESCRIPTION
I encounter the requirement when trying to call function writing in C code, which pass data in pointer to byte array.
It will be good if the vint can convert to and from the bytes array.  
This change add the tests for such functions, and we can discuss the behavior first.