### PR TITLE
Support HexString Serialize and Add Binary Source with Test

### DIFF
--- a/vtuber/source.h
+++ b/vtuber/source.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "verilog/dtype.h"
+#include "verilog/serialize.h"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -17,13 +18,23 @@ template <typename T> class VintHexSource : public Source<T> {
 
 public:
   ::std::vector<T> get(::std::istream &ist) override {
-    verilog::vuint<verilog::bits<T>()> buf;
     ::std::vector<T> data;
-    ::std::string line;
-    while (::std::getline(ist, line)) {
-      from_string(buf, line, 16);
-      T t;
-      verilog::unpack(t, buf);
+    T t;
+    while (verilog::LoadHexString(ist, t)) {
+      data.push_back(t);
+    }
+    return data;
+  }
+};
+
+template <typename T> class VintBinarySource : public Source<T> {
+  static_assert(verilog::is_dtype_v<T>, "T must be a verilog type");
+
+public:
+  ::std::vector<T> get(::std::istream &ist) override {
+    ::std::vector<T> data;
+    T t;
+    while (verilog::LoadBinary(ist, t)) {
       data.push_back(t);
     }
     return data;

--- a/vtuber/source_test.cpp
+++ b/vtuber/source_test.cpp
@@ -59,3 +59,59 @@ TEST(TestSource, HexSourceStruct) {
     EXPECT_EQ(t.value(), 0xcaaa8a6a4a2a0a);
   }
 }
+
+TEST(TestSource, BinarySource) {
+  stringstream bin;
+  verilog::SaveBinary(bin, verilog::vuint<64>(0xafadaba9a7a5a3a1));
+  verilog::SaveBinary(bin, verilog::vuint<64>(0xeacaaa8a6a4a2a0a));
+  unique_ptr<Source<V64>> s(new VintBinarySource<V64>());
+  auto v64 = s->get(bin);
+  EXPECT_EQ(v64.size(), 2);
+  EXPECT_EQ(v64[0].value(), 0xafadaba9a7a5a3a1);
+  EXPECT_EQ(v64[1].value(), 0xeacaaa8a6a4a2a0a);
+}
+
+TEST(TestSource, BinarySourceArray) {
+  stringstream bin;
+  verilog::SaveBinary(bin, verilog::vuint<64>(0xafadaba9a7a5a3a1));
+  verilog::SaveBinary(bin, verilog::vuint<64>(0xeacaaa8a6a4a2a0a));
+  unique_ptr<Source<A32>> s(new VintBinarySource<A32>());
+  auto a32 = s->get(bin);
+  EXPECT_EQ(a32.size(), 2);
+  EXPECT_EQ(a32[0][0].value(), 0xa7a5a3a1);
+  EXPECT_EQ(a32[0][1].value(), 0xafadaba9);
+  EXPECT_EQ(a32[1][0].value(), 0x6a4a2a0a);
+  EXPECT_EQ(a32[1][1].value(), 0xeacaaa8a);
+}
+
+// The layout of struct is likely to have "hole" due to alignement
+// It is not recommended to read struct with LoadBinary while the source
+// is created from plain hex string
+TEST(TestSource, BinarySourceStruct) {
+  stringstream bin;
+  S56 buf0, buf1;
+
+  // push buf0
+  buf0.s8.b0 = 1;
+  buf0.s8.b1 = 2;
+  buf0.s8.b2 = 3;
+  buf0.a16[0] = 0x5a;
+  buf0.a16[1] = 0xa5;
+  buf0.v32 = 0x12345678;
+  verilog::SaveBinary(bin, buf0);
+
+  // push buf1
+  buf1.s8.b0 = 1;
+  buf1.s8.b1 = 2;
+  buf1.s8.b2 = 3;
+  buf1.a16[0] = 0x3f;
+  buf1.a16[1] = 0x85;
+  buf1.v32 = 0x90abcdef;
+  verilog::SaveBinary(bin, buf1);
+
+  unique_ptr<Source<S56>> s(new VintBinarySource<S56>());
+  auto s56 = s->get(bin);
+  EXPECT_EQ(s56.size(), 2);
+  EXPECT_FALSE(memcmp(&s56[0], &buf0, sizeof(S56)));
+  EXPECT_FALSE(memcmp(&s56[1], &buf1, sizeof(S56)));
+}

--- a/vtuber/verilog/serialize.h
+++ b/vtuber/verilog/serialize.h
@@ -1,20 +1,37 @@
 #pragma once
+#include "operation/pack.h"
+#include "operation/unpack.h"
 #include <iostream>
 
 namespace verilog {
 
-template <class T>
-::std::ostream& SaveContent(::std::ostream &os, const T& rhs) {
-	static_assert(::std::is_trivially_copyable_v<T>);
-	os.write(reinterpret_cast<const char*>(&rhs), sizeof(T));
-	return os;
+template <class T>::std::ostream &SaveBinary(::std::ostream &os, const T &rhs) {
+  static_assert(::std::is_trivially_copyable_v<T>);
+  os.write(reinterpret_cast<const char *>(&rhs), sizeof(T));
+  return os;
+};
+
+template <class T>::std::istream &LoadBinary(::std::istream &ist, T &rhs) {
+  static_assert(::std::is_trivially_copyable_v<T>);
+  ist.read(reinterpret_cast<char *>(&rhs), sizeof(T));
+  return ist;
 };
 
 template <class T>
-::std::istream& LoadContent(::std::istream &ist, T& rhs) {
-	static_assert(::std::is_trivially_copyable_v<T>);
-	ist.read(reinterpret_cast<char*>(&rhs), sizeof(T));
-	return ist;
-};
+::std::ostream &SaveHexString(::std::ostream &os, const T &rhs) {
+  static_assert(verilog::is_dtype_v<T>);
+  os.write(to_hex(pack(rhs)));
+  return os;
+}
+
+template <class T>::std::istream &LoadHexString(::std::istream &ist, T &rhs) {
+  static_assert(verilog::is_dtype_v<T>);
+  verilog::vuint<verilog::bits<T>()> buf;
+  ::std::string line;
+  ::std::getline(ist, line);
+  from_string(buf, line, 16);
+  verilog::unpack(rhs, buf);
+  return ist;
+}
 
 } // namespace verilog


### PR DESCRIPTION
This PR contains:
* Move HexString serialize function to `serialize.h`
* Add Binary Source to read binary content to vector
* Add test for binary source.