### PR TITLE
Replace unsupport syntax and warning in DC

### DIFF
--- a/verilog/Montgomery.sv
+++ b/verilog/Montgomery.sv
@@ -29,8 +29,8 @@ assign o_out = mod_result[MOD_WIDTH - 1 : 0];
 
 // loop variable
 logic loop_o_valid, loop_o_ready;
-logic loop_init, loop_next;
-logic loop_done = round_counter == MOD_WIDTH;
+logic loop_init, loop_next, loop_done;
+assign loop_done = round_counter == MOD_WIDTH;
 
 // read input data
 always_ff @( posedge clk or negedge rst_n ) begin

--- a/verilog/PipelineCombine.sv
+++ b/verilog/PipelineCombine.sv
@@ -9,10 +9,14 @@ module PipelineCombine
     input o_ready
 );
 
-
 // o_valid should be set:
 // 1. when all inputs are valid
-assign o_valid = i_valid.and();
+always_comb begin
+  o_valid = 1'b1;
+  for (int i = 0; i < N; i++) begin
+    o_valid = o_valid & i_valid[i];
+  end
+end
 
 // i_ready reflect o_ready in-time
 always_comb begin

--- a/verilog/PipelineDistribute.sv
+++ b/verilog/PipelineDistribute.sv
@@ -28,7 +28,12 @@ end
 always_comb begin
   foreach(ready_sent[i]) ready_sent[i] = o_ready[i] | o_sent[i];
 end
-assign i_ready = ready_sent.and();
+always_comb begin
+  i_ready = 1'b1;
+  foreach(ready_sent[i]) begin
+    i_ready = i_ready && ready_sent[i];
+  end
+end
 
 always_ff @( posedge clk or negedge rst_n ) begin
   if (!rst_n) begin o_sent <= '{N{'0}}; end


### PR DESCRIPTION
[.and()](https://verificationguide.com/systemverilog/systemverilog-array-reduction-methods/#Array_reduction_method_AND) operator is not supported in DC. What a garbage tool